### PR TITLE
Allow videos to start at a specified time

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -29,8 +29,8 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                             'controls': 0,
                             'showinfo': 0,
                             'rel': 0,
-                            'autoplay': 0
-                            //Switch autoplay to 1 to autoplay videos
+                            'autoplay': 0, //Switch autoplay to 1 to autoplay videos
+                            'start': 0
                         };
 
                         if (optionsArr !== null) {


### PR DESCRIPTION
This change simply allows the `start` parameter which directs YouTube to start the video at the specified number of seconds. This is required in our use case to resume a video that the user was watching earlier when the original directive had since been destroyed.

Sample usage:
```html
<vg-video vg-src="config.sources" vg-youtube="rel=1;showinfo=1;start={{config.start}}"></vg-video>
```
```html
<vg-media vg-src="config.sources" vg-youtube="start=30"></vg-media>
```