### PR TITLE
Adds a note to the README about mobile fullscreen issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ angular.module("videogularApp",
 
 And that's all :)
 
+### A note on mobile fullscreen support
+
+The YouTube iframe API does not provide a programmatic way to make a video fullscreen. If the Videogular full screen button is enabled for YouTube videos, it will not work.
+
+While good results may be obtained by making the `iframe` or `videogular` element fullscreen on Android, this currently is not supported on iOS which can only make `video` elements fullscreen. The only way to support fullscreen YouTube videos on iPad is to show the YouTube controls and allow the user to tap the fullscreen button. If YouTube controls are enabled, ensure that any videogular elements that would cover the iframe, such as `vg-controls`, `vg-overlay-play`, and `vg-poster` are disabled so that the user can interact with the controls inside the YouTube iframe.
+
 ### Donate
 
 If project help you, you can donate me


### PR DESCRIPTION
I would like to save others the several days I spent trying to get fullscreen videos working properly on mobile devices by including a note in the README. 

A bit more background on the problem in case it might be considered for later improvement:

The `iframe` element inserted by this plugin via the YouTube API is not recognized by videogular. Videogular attaches listeners to and calls methods on its `mediaElement`, which via `vgType` can be either a `video` or `audio` element. This plugin inserts some behavior into the `mediaElement` to bridge it with the YouTube API. Fullscreen operations in videogular that call methods on the `mediaElement` do not work since there is no `video` in the DOM (the iframe content is off-limits due to cross-domain security, I don't think we can work around that).

On Android I experimented with setting `API.mediaElement = elem.closest('videogular');` at the top of the plugin's `onVideoReady` function. This was actually kind of nice on Android since the fullscreen button in videogular's controls made the entire `videogular` element fullscreen, with consistent media controls. There are some non-insurmountable problems with that on Android, but unfortunately it does not work at all on iOS since `webkitEnterFullscreen()` and company are only defined on `video` elements.

The only option left to me was to disable (`ngIf`) everything from Videogular that overlays the iframe in order to use the YouTube controls. I am still enjoying the benefit of a consistent API for tracking playback status, but unfortunately abandoning the videogular controls and overlays for YouTube was the only option.