### PR TITLE
Fix error when src is trusted via $sce

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -139,7 +139,10 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                         }
 
                         function isYoutube(url) {
-                            return url.match(youtubeReg);
+                            if (url) {
+                                return url.match(youtubeReg);
+                            }
+                            return false;
                         }
 
                         function onSourceChange(url) {
@@ -156,7 +159,12 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                                 return API.sources;
                             },
                             function(newVal, oldVal) {
-                                onSourceChange(newVal[0].src.toString());
+                                if (newVal && newVal.length > 0 && newVal[0].src) {
+                                    onSourceChange(newVal[0].src.toString());
+                                }
+                                else {
+                                    onSourceChange(null);
+                                }
                             }
                         );
                         scope.$on('$destroy', function() {

--- a/youtube.js
+++ b/youtube.js
@@ -156,7 +156,7 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                                 return API.sources;
                             },
                             function(newVal, oldVal) {
-                                onSourceChange(newVal[0].src);
+                                onSourceChange(newVal[0].src.toString());
                             }
                         );
                         scope.$on('$destroy', function() {


### PR DESCRIPTION
When `$sce.trustAsResourceUrl()` or similar is used to trust the `src` URL, the value is an object rather than a string. The plugin expects a string, throwing an exception when attempting to match it against the YouTube regex.

This change uses `toString()` to unwrap the `src` URL before matching. Additionally, some error checking should introduce the ability to clean up the YouTube player if the `sources` array is emptied.