### PR TITLE
Broadcasting Youtube Player event

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -110,6 +110,9 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                             }
                             updateTimer = setInterval(updateTime, 600);
                             angular.element(ytplayer.getIframe()).css({'width':'100%','height':'100%'});
+                            
+                            $rootScope.$broadcast('ytVideoReady', true);
+
                         }
 
                         function onVideoStateChange(event) {
@@ -145,6 +148,8 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                                     //No appropriate state
                                 break;
                             }
+                            
+                            $rootScope.$broadcast('ytVideoStateChange', event.data);
                         }
 
                         function isYoutube(url) {

--- a/youtube.js
+++ b/youtube.js
@@ -111,7 +111,7 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                             updateTimer = setInterval(updateTime, 600);
                             angular.element(ytplayer.getIframe()).css({'width':'100%','height':'100%'});
                             
-                            $rootScope.$broadcast('ytVideoReady', true);
+                            $rootScope.$emit('ytVideoReady');
 
                         }
 
@@ -149,7 +149,7 @@ angular.module("info.vietnamcode.nampnq.videogular.plugins.youtube", [])
                                 break;
                             }
                             
-                            $rootScope.$broadcast('ytVideoStateChange', event.data);
+                            $rootScope.$emit('ytVideoStateChange', event.data);
                         }
 
                         function isYoutube(url) {


### PR DESCRIPTION
These changes add the broadcasting of 2 events:

- ***ytVideoReady*** - fired when the _onVideoReady_ is completed;

- ***ytVideoStateChange*** - fired when an _onVideoStateChange_ event occurs on a player.
The landing state of the player could be retrieved from the broadcasted data.